### PR TITLE
Add support for the playlistId attribute.

### DIFF
--- a/demo_playlist.html
+++ b/demo_playlist.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>&lt;google-youtube-video-wall&gt; Demo (Playlists)</title>
+    <script src="../platform/platform.js"></script>
+    <link rel="import" href="google-youtube-video-wall.html">
+  </head>
+
+  <body unresolved>
+    <!-- Please register for your own key! https://developers.google.com/youtube/registering_an_application -->
+    <google-youtube-video-wall fit
+                               apiKey="AIzaSyAcB7qNYPC6bI7e3PHscV8w5-acmocWhmE"
+                               playlistId="PLOU2XLYxmsII8L540LbY5hdC23cmoZMhV">
+    </google-youtube-video-wall>
+  </body>
+</html>

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -39,7 +39,7 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
 -->
 
 <polymer-element name="google-youtube-video-wall"
-                 attributes="apiKey channelId location locationRadius maxResults maxVideos narrowWidth order publishedAfter publishedBefore q safeSearch showSearch topicId veryNarrowWidth videoCategoryId wallTitle">
+                 attributes="apiKey channelId location locationRadius maxResults maxVideos narrowWidth order playlistId publishedAfter publishedBefore q safeSearch showSearch topicId veryNarrowWidth videoCategoryId wallTitle">
   <template>
     <link rel="stylesheet" href="google-youtube-video-wall.css">
 
@@ -77,9 +77,9 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
 
             <template repeat="{{video in _videos}}">
               <div class="video-container"
-                       data-video-id="{{video.id.videoId}}"
-                       data-video-title="{{video.snippet.title}}"
-                       on-tap="{{handleItemSelected}}">
+                   data-video-id="{{video.id.videoId || video.snippet.resourceId.videoId}}"
+                   data-video-title="{{video.snippet.title}}"
+                   on-tap="{{handleItemSelected}}">
                 <paper-shadow z="1"></paper-shadow>
                 <paper-ripple fit></paper-ripple>
 
@@ -152,13 +152,24 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
       </section>
     </core-animated-pages>
 
-    <template if="{{_youtubeApiSearchParams}}">
+    <template if="{{_youtubeApiParams && _youtubeApiService}}">
       <core-ajax auto
-                 url="https://www.googleapis.com/youtube/v3/search"
-                 params="{{_youtubeApiSearchParams}}"
+                 url="https://www.googleapis.com/youtube/v3/{{_youtubeApiService}}"
+                 params="{{_youtubeApiParams}}"
                  handleAs="json"
-                 on-core-response="{{handleSearchResponse}}"
-                 on-core-error="{{handleSearchError}}">
+                 on-core-response="{{handleYouTubeApiResponse}}"
+                 on-core-error="{{handleYouTubeApiError}}">
+      </core-ajax>
+    </template>
+
+    <!-- Get the wall's title from the playlist's title if we're using a playlist id. -->
+    <template if="{{playlistId && wallTitle === ''}}">
+      <core-ajax auto
+                 url="https://www.googleapis.com/youtube/v3/playlists"
+                 params='{"part": "snippet", "id": "{{playlistId}}", "key": "{{apiKey}}"}'
+                 handleAs="json"
+                 on-core-response="{{handlePlaylistListResponse}}"
+                 on-core-error="{{handleYouTubeApiError}}">
       </core-ajax>
     </template>
   </template>
@@ -275,6 +286,20 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
         order: 'relevance',
 
         /**
+         * If `playlistId` is specified, then the video wall will be populated with the contents of that YouTube playlist.
+         *
+         * Any search-related attributes will be ignored as long this attribute is set.
+         *
+         * `this.showSearch` will be set to `false`, since it's not possible to filter the contents of a playlist based
+         * on a search term using the YouTube Data API v3.
+         *
+         * @attribute playlistId
+         * @type string
+         * @default ''
+         */
+        playlistId: '',
+
+        /**
          * An optional search filter which limits the results to videos that were published after a certain date.
          *
          * If set, you must use an [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
@@ -384,35 +409,52 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
          *
          * @attribute wallTitle
          * @type string
-         * @default 'YouTube Videos'
+         * @default ''
          */
-        wallTitle: 'YouTube Videos',
+        wallTitle: '',
 
         // Placeholder, since the YT Player doesn't like being initialized without a video id.
         _selectedVideoId: 'mN7IAaRdi_k',
         _selectedVideoTitle: '',
         _nextPageToken: '',
-        _youtubeApiSearchParams: '',
+        // This will be set to either 'search' or 'playlistItems', depending on the other attributes.
+        _youtubeApiService: '',
+        _youtubeApiParams: '',
         _videos: null,
         _apiError: '',
 
-        updateYouTubeApiSearchParams: function() {
-          var params = {
-            part: 'snippet',
-            pageToken: this._nextPageToken,
-            type: 'video',
-            videoEmbeddable: 'true',
-            key: this.apiKey,
-            maxResults: this.maxResultsPerRequest,
-            channelId: this.channelId,
-            location: this.location,
-            locationRadius: this.locationRadius,
-            order: this.order,
-            q: this.q,
-            safeSearch: this.safeSearch,
-            topicId: this.topicId,
-            videoCategoryId: this.videoCategoryId
-          };
+        updateYouTubeApiParams: function() {
+          var params;
+
+          if (this.playlistId) {
+            this.showSearch = false;
+            this._youtubeApiService = 'playlistItems';
+            params = {
+              key: this.apiKey,
+              part: 'snippet',
+              pageToken: this._nextPageToken,
+              playlistId: this.playlistId,
+              maxResults: this.maxResultsPerRequest
+            };
+          } else {
+            this._youtubeApiService = 'search';
+            params = {
+              key: this.apiKey,
+              part: 'snippet',
+              pageToken: this._nextPageToken,
+              type: 'video',
+              videoEmbeddable: 'true',
+              maxResults: this.maxResultsPerRequest,
+              channelId: this.channelId,
+              location: this.location,
+              locationRadius: this.locationRadius,
+              order: this.order,
+              q: this.q,
+              safeSearch: this.safeSearch,
+              topicId: this.topicId,
+              videoCategoryId: this.videoCategoryId
+            };
+          }
 
           Object.keys(params).forEach(function(key) {
             if (params[key] === '') {
@@ -420,10 +462,10 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
             }
           });
 
-          this._youtubeApiSearchParams = JSON.stringify(params);
+          this._youtubeApiParams = JSON.stringify(params);
         },
 
-        handleSearchResponse: function(e) {
+        handleYouTubeApiResponse: function(e) {
           this._apiError = '';
           var response = e.detail.response;
 
@@ -438,14 +480,23 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
 
           if (response.nextPageToken && this._videos.length < this.maxVideos) {
             this._nextPageToken = response.nextPageToken;
-            this.async(this.updateYouTubeApiSearchParams);
+            this.async(this.updateYouTubeApiParams);
           } else if (this._videos.length > this.maxVideos) {
             // If we have more results that we require, truncate the array by setting its length.
             this._videos.length = this.maxVideos;
           }
         },
 
-        handleSearchError: function(e) {
+        handlePlaylistListResponse: function(e) {
+          this._apiError = '';
+          var response = e.detail.response;
+
+          if (response.items) {
+            this.wallTitle = response.items[0].snippet.title;
+          }
+        },
+
+        handleYouTubeApiError: function(e) {
           if (e.detail.response.indexOf('keyInvalid') >= 0) {
             this._apiError = 'Missing or invalid API key. Please see the <google-youtube-video-wall> ' +
               'documentation for information on setting the "apiKey" property to a valid value.'
@@ -491,14 +542,14 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
         },
 
         observe: {
-          'apiKey channelId location locationRadius maxResults order publishedAfter publishedBefore q safeSearch topicId videoCategoryId': function() {
+          'apiKey channelId location locationRadius maxResults order playlistId publishedAfter publishedBefore q safeSearch topicId videoCategoryId': function() {
             this._nextPageToken = '';
-            this.updateYouTubeApiSearchParams();
+            this.updateYouTubeApiParams();
           }
         },
 
         ready: function() {
-          this.updateYouTubeApiSearchParams();
+          this.updateYouTubeApiParams();
         }
       });
   </script>

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -162,16 +162,13 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
       </core-ajax>
     </template>
 
-    <!-- Get the wall's title from the playlist's title if we're using a playlist id. -->
-    <template if="{{playlistId && wallTitle === ''}}">
-      <core-ajax auto
-                 url="https://www.googleapis.com/youtube/v3/playlists"
-                 params='{"part": "snippet", "id": "{{playlistId}}", "key": "{{apiKey}}"}'
-                 handleAs="json"
-                 on-core-response="{{handlePlaylistListResponse}}"
-                 on-core-error="{{handleYouTubeApiError}}">
-      </core-ajax>
-    </template>
+    <core-ajax id="titleajax"
+               url="https://www.googleapis.com/youtube/v3/playlists"
+               params='{"part": "snippet", "id": "{{playlistId}}", "key": "{{apiKey}}"}'
+               handleAs="json"
+               on-core-response="{{handlePlaylistTitleResponse}}"
+               on-core-error="{{handleYouTubeApiError}}">
+    </core-ajax>
   </template>
 
   <script>
@@ -487,7 +484,7 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
           }
         },
 
-        handlePlaylistListResponse: function(e) {
+        handlePlaylistTitleResponse: function(e) {
           this._apiError = '';
           var response = e.detail.response;
 
@@ -542,7 +539,20 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
         },
 
         observe: {
-          'apiKey channelId location locationRadius maxResults order playlistId publishedAfter publishedBefore q safeSearch topicId videoCategoryId': function() {
+          'apiKey channelId location locationRadius maxResults order publishedAfter publishedBefore q safeSearch topicId videoCategoryId': function() {
+            this._nextPageToken = '';
+            this.updateYouTubeApiParams();
+          }
+        },
+
+        playlistIdChanged: function() {
+          // Check to make sure that playlistId isn't being reset to something false...
+          if (this.playlistId) {
+            // Only overwrite this.wallTitle if it's not being explicitly set by the element.
+            if(!this.hasAttribute('wallTitle')) {
+              this.$.titleajax.go();
+            }
+
             this._nextPageToken = '';
             this.updateYouTubeApiParams();
           }


### PR DESCRIPTION
@ebidel @addyosmani & co.:

This closes #1, by adding in support for a new `playlistId` attribute. If present, the search terms will be ignored, and if `wallTitle` isn't already set, the playlist's title will be used.
