### PR TITLE
Misc. performance/UI improvements

### DIFF
--- a/google-youtube-video-wall.css
+++ b/google-youtube-video-wall.css
@@ -46,6 +46,10 @@ paper-input /deep/ input {
   border-radius: 2px;
 }
 
+.video-container > paper-ripple {
+  z-index: 1;
+}
+
 .video-container > img {
   position: relative;
   width: 100%;

--- a/google-youtube-video-wall.css
+++ b/google-youtube-video-wall.css
@@ -47,6 +47,7 @@ paper-input /deep/ input {
 }
 
 .video-container > img {
+  position: relative;
   width: 100%;
   display: block;
   overflow: hidden;

--- a/google-youtube-video-wall.css
+++ b/google-youtube-video-wall.css
@@ -37,6 +37,7 @@ paper-input /deep/ input {
 
 .video-container {
   cursor: pointer;
+  position: relative;
   display: inline-block;
   width: 320px;
   height: 320px;
@@ -44,6 +45,7 @@ paper-input /deep/ input {
   vertical-align: top;
   margin: 8px 8px 8px 0;
   border-radius: 2px;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
 }
 
 .video-container > paper-ripple {

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -503,8 +503,8 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
         },
 
         handleItemSelected: function(e) {
-          this._selectedVideoTitle = e.srcElement.parentNode.dataset.videoTitle;
-          this._selectedVideoId = e.srcElement.parentNode.dataset.videoId;
+          this._selectedVideoTitle = e.target.parentNode.dataset.videoTitle;
+          this._selectedVideoId = e.target.parentNode.dataset.videoId;
           this.$.corepage.selected = 1;
         },
 

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -14,7 +14,6 @@
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="../paper-slider/paper-slider.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
-<link rel="import" href="../paper-shadow/paper-shadow.html">
 <link rel="import" href="../polymer/polymer.html">
 
 
@@ -83,7 +82,6 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
                    data-video-id="{{video.id.videoId || video.snippet.resourceId.videoId}}"
                    data-video-title="{{video.snippet.title}}"
                    on-click="{{handleItemSelected}}">
-                <paper-shadow z="1"></paper-shadow>
                 <paper-ripple fit></paper-ripple>
 
                 <img src="{{video.snippet.thumbnails.medium.url}}"

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -39,7 +39,7 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
 -->
 
 <polymer-element name="google-youtube-video-wall"
-                 attributes="apiKey channelId location locationRadius maxResults maxVideos narrowWidth order playlistId publishedAfter publishedBefore q safeSearch showSearch topicId veryNarrowWidth videoCategoryId wallTitle">
+                 attributes="apiKey channelId location locationRadius maxResultsPerRequest maxVideos narrowWidth order playlistId publishedAfter publishedBefore q safeSearch showSearch topicId veryNarrowWidth videoCategoryId wallTitle">
   <template>
     <link rel="stylesheet" href="google-youtube-video-wall.css">
 

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -52,7 +52,10 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
                          selected="0"
                          on-core-animated-pages-transition-end="{{handleTransitionEnd}}">
       <section>
-        <core-header-panel id="resultspage" fit cross-fade>
+        <core-header-panel id="resultspage"
+                           fit
+                           cross-fade
+                           on-scroll="{{handleResultsScroll}}">
           <core-toolbar class="{{ {'medium-tall': narrow && showSearch} | tokenList }}">
             <header flex>{{wallTitle}}</header>
 
@@ -65,7 +68,7 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
             </template>
           </core-toolbar>
 
-          <div id="searchresults" class="{{ {veryNarrow: veryNarrow} | tokenList }}">
+          <div id="searchresults" class="{{ {veryNarrow: veryNarrow} | tokenList }}" hero-p>
             <template if="{{_apiError}}">
               <h1>Oops! The following error occurred:</h1>
               <pre>{{_apiError}}</pre>
@@ -79,13 +82,13 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
               <div class="video-container"
                    data-video-id="{{video.id.videoId || video.snippet.resourceId.videoId}}"
                    data-video-title="{{video.snippet.title}}"
-                   on-tap="{{handleItemSelected}}">
+                   on-click="{{handleItemSelected}}">
                 <paper-shadow z="1"></paper-shadow>
                 <paper-ripple fit></paper-ripple>
 
                 <img src="{{video.snippet.thumbnails.medium.url}}"
                      hero-id="{{video.id.videoId}}"
-                     hero>
+                     hero?="{{video.id.videoId === _selectedVideoId}}">
                 <div class="text-container">
                   <h1>{{video.snippet.title}}</h1>
                   <p>{{video.snippet.description}}</p>
@@ -101,6 +104,7 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
           <template if="{{_selectedVideoId}}">
             <paper-icon-button id="close-button"
                                icon="close"
+                               fill
                                on-tap="{{handlePlayerClose}}">
             </paper-icon-button>
 
@@ -477,7 +481,6 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
 
           if (response.nextPageToken && this._videos.length < this.maxVideos) {
             this._nextPageToken = response.nextPageToken;
-            this.async(this.updateYouTubeApiParams);
           } else if (this._videos.length > this.maxVideos) {
             // If we have more results that we require, truncate the array by setting its length.
             this._videos.length = this.maxVideos;
@@ -503,18 +506,24 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
         },
 
         handleItemSelected: function(e) {
-          this._selectedVideoTitle = e.target.parentNode.dataset.videoTitle;
-          this._selectedVideoId = e.target.parentNode.dataset.videoId;
-          this.$.corepage.selected = 1;
+          // Wait before starting the transition to the play page to give the paper-ripple effect time to animate.
+          this.async(function(args) {
+            this._selectedVideoTitle = args.title;
+            this._selectedVideoId = args.videoId;
+            this.$.corepage.selected = 1;
+          }, { title: e.target.parentNode.dataset.videoTitle, videoId: e.target.parentNode.dataset.videoId }, 150);
         },
 
         handlePlayerClose: function() {
-          this.shadowRoot.querySelector('#youtubeplayer').pause();
-          this.$.corepage.selected = 0;
+          // Wait before starting the transition to the results page to give the paper-ripple effect time to animate.
+          this.async(function() {
+            this.shadowRoot.querySelector('#youtubeplayer').pause();
+            this.$.corepage.selected = 0;
 
-          this.state = -1;
-          this.currentTime = 0;
-          this.fractionLoaded = 0;
+            this.state = -1;
+            this.currentTime = 0;
+            this.fractionLoaded = 0;
+          }, null, 75);
         },
 
         handlePlay: function() {
@@ -535,6 +544,14 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
           // We can't reset it prior to the transition since it will mess up the hero-id mapping.
           if (this.$.corepage.selected == 0) {
             this._selectedVideoId = '';
+          }
+        },
+
+        handleResultsScroll: function(e) {
+          // 320 is the height of the video container, so this check is roughly equivalent to
+          // "is the bottom of the scroll area on the second-to-last row?"
+          if ((e.detail.target.scrollTop + e.detail.target.clientHeight + 320) >= e.detail.target.scrollHeight) {
+            this.async(this.updateYouTubeApiParams);
           }
         },
 

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -481,6 +481,10 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
 
           if (response.nextPageToken && this._videos.length < this.maxVideos) {
             this._nextPageToken = response.nextPageToken;
+
+            if (this.$.resultspage.scroller.clientHeight == this.$.resultspage.scroller.scrollHeight) {
+              this.async(this.updateYouTubeApiParams);
+            }
           } else if (this._videos.length > this.maxVideos) {
             // If we have more results that we require, truncate the array by setting its length.
             this._videos.length = this.maxVideos;


### PR DESCRIPTION
@ebidel @addyosmani & co.:

This contains some tweaks/UI polish:
- The thumbnail `<img>` no longer appears behind the other items in the results page during the player -> results hero transition. (The fix was to set `position: relative` on the `<img>` so that the `z-index` set by the hero transition would be honored.)
- There's now a small delay in between clicking/tapping on items with ripples before the hero transition is kicked off. This ensure that the ripple effect has had a chance to animate a bit, resolving some jankiness due to the simultaneous animations.
- Additional pages of results are now being lazy-loaded when the user scrolls down to the second-to-last row. This is a good idea from an API efficiency perspective. It also helps mask a larger problem, tracked in #5, in which Firefox and IE 11 are both slowed down significantly each time a new page of results are displayed.
- `srcElement` -> `target` in one event handler, to ensure compatibility with modern browsers.

This closes #2 
