### PR TITLE
Apply `position: absolute` to the YouTube Player <iframe>.

### DIFF
--- a/google-youtube-video-wall.css
+++ b/google-youtube-video-wall.css
@@ -13,6 +13,10 @@
   bottom: 64px;
 }
 
+#youtubeplayer /deep/ iframe {
+  position: absolute;
+}
+
 #playerpage.narrow #youtubeplayer {
   bottom: 128px;
 }


### PR DESCRIPTION
Small fix needed to properly size the player in Internet Explorer.
