### PR TITLE
Clip long titles on play page.

### DIFF
--- a/google-youtube-video-wall.css
+++ b/google-youtube-video-wall.css
@@ -86,6 +86,11 @@ paper-input /deep/ #focusedUnderline {
   margin: 8px 16px 16px 16px;
 }
 
+.video-title {
+  max-height: 48px;
+  overflow-y: hidden;
+}
+
 paper-slider {
   position: absolute;
   width: 100%;

--- a/google-youtube-video-wall.html
+++ b/google-youtube-video-wall.html
@@ -148,7 +148,7 @@ and the [YouTube Data API v3](https://developers.google.com/youtube/v3/) searche
               </paper-fab>
             </template>
 
-            <p flex>{{_selectedVideoTitle}}</p>
+            <p flex class="video-title">{{_selectedVideoTitle}}</p>
 
             <p class="{{ {bottom: narrow} | tokenList }}" hidden?="{{duration == 0}}">{{currentTimeFormatted}}/{{durationFormatted}}</p>
           </core-toolbar>


### PR DESCRIPTION
Ensure that long video titles don't cause the text to obscure the player.
